### PR TITLE
update .sh install scripts with latest changes to the pyne repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Example for installing the most recent stable branch on Ubuntu 16.04:
     
 Example for installing the develop branch on Mint 18.01:
 	
-	./ubuntu_16.04.sh dev
+	./mint_18.01.sh dev
 
 Docker Builds (*.dockerfile)
 ----------------------------

--- a/README.md
+++ b/README.md
@@ -12,9 +12,17 @@ Install scripts are available for different versions of both Ubuntu and
 Mint operating systems. The script used to install PyNE should correspond
 to the user's operating system and version. The intention of these
 scripts is that PyNE can be ready to use on a clean install of any of
-the supported operating systems. Example for installing on Ubuntu 16.04:
+the supported operating systems. Furthermore, the user should choose either
+to build a stable version of PyNE or the current develop
+branch of PyNE by supplying a second argument. 
 
-    ./ubuntu_16.04.sh
+Example for installing the most recent stable branch on Ubuntu 16.04:
+
+    ./ubuntu_16.04.sh stable
+    
+Example for installing the develop branch on Mint 18.01:
+	
+	./ubuntu_16.04.sh dev
 
 Docker Builds (*.dockerfile)
 ----------------------------

--- a/mint_17.03.sh
+++ b/mint_17.03.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 # This script builds the repo version of PyNE (with the MOAB optional 
-# dependency) from scratch on Ubuntu 15.04. The folder $HOME/opt is created 
+# dependency) from scratch on Mint 17.03. The folder $HOME/opt is created 
 # and PyNE is installed within.
 #
-# Run this script from any directory by issuing the command:
-# $ ./ubuntu_16.04.sh
+# Run this script from any directory by issuing the command where <version>
+# is either "dev" or "stable":
+# $ ./mint_17.03.sh <version>
 # After the build finishes run:
 #  $ source ~/.bashrc
 # or open a new terminal.
@@ -20,4 +21,4 @@ package_list="software-properties-common python-software-properties wget \
 hdf5_libdir=/usr/lib/x86_64-linux-gnu
 
 
-source ubuntu_mint.sh
+source ubuntu_mint.sh $1

--- a/mint_18.01.sh
+++ b/mint_18.01.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 # This script builds the repo version of PyNE (with the MOAB optional 
-# dependency) from scratch on Ubuntu 15.04. The folder $HOME/opt is created 
+# dependency) from scratch on Mint 18.01. The folder $HOME/opt is created 
 # and PyNE is installed within.
 #
-# Run this script from any directory by issuing the command:
-# $ ./ubuntu_16.04.sh
+# Run this script from any directory by issuing the command where <version>
+# is either "dev" or "stable":
+# $ ./mint_18.01.sh <version>
 # After the build finishes run:
 #  $ source ~/.bashrc
 # or open a new terminal.
@@ -20,4 +21,4 @@ package_list="software-properties-common python-software-properties wget \
 hdf5_libdir=/usr/lib/x86_64-linux-gnu/hdf5/serial
 
 
-source ubuntu_mint.sh
+source ubuntu_mint.sh $1

--- a/ubuntu_14.04.sh
+++ b/ubuntu_14.04.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 # This script builds the repo version of PyNE (with the MOAB optional 
-# dependency) from scratch on Ubuntu 15.04. The folder $HOME/opt is created 
+# dependency) from scratch on Ubuntu 14.04. The folder $HOME/opt is created 
 # and PyNE is installed within.
 #
-# Run this script from any directory by issuing the command:
-# $ ./ubuntu_14.04.sh
+# Run this script from any directory by issuing the command where <version>
+# is either "dev" or "stable":
+# $ ./ubuntu_14.04.sh <version>
 # After the build finishes run:
 #  $ source ~/.bashrc
 # or open a new terminal.
@@ -18,4 +19,4 @@ package_list="software-properties-common python-software-properties wget \
 hdf5_libdir=/usr/lib/x86_64-linux-gnu
 
 
-source ubuntu_mint.sh
+source ubuntu_mint.sh $1

--- a/ubuntu_15.04.sh
+++ b/ubuntu_15.04.sh
@@ -3,8 +3,9 @@
 # dependency) from scratch on Ubuntu 15.04. The folder $HOME/opt is created 
 # and PyNE is installed within.
 #
-# Run this script from any directory by issuing the command:
-# $ ./ubuntu_15.04.sh
+# Run this script from any directory by issuing the command where <version>
+# is either "dev" or "stable":
+# $ ./ubuntu_15.04.sh <version>
 # After the build finishes run:
 #  $ source ~/.bashrc
 # or open a new terminal.
@@ -18,4 +19,4 @@ package_list="software-properties-common python-software-properties wget \
 hdf5_libdir=/usr/lib/x86_64-linux-gnu/hdf5/serial
 
 
-source ubuntu_mint.sh
+source ubuntu_mint.sh $1

--- a/ubuntu_16.04.sh
+++ b/ubuntu_16.04.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 # This script builds the repo version of PyNE (with the MOAB optional 
-# dependency) from scratch on Ubuntu 15.04. The folder $HOME/opt is created 
+# dependency) from scratch on Ubuntu 16.04. The folder $HOME/opt is created 
 # and PyNE is installed within.
 #
-# Run this script from any directory by issuing the command:
-# $ ./ubuntu_16.04.sh
+# Run this script from any directory by issuing the command where <version>
+# is either "dev" or "stable":
+# $ ./ubuntu_16.04.sh <version>
 # After the build finishes run:
 #  $ source ~/.bashrc
 # or open a new terminal.
@@ -18,4 +19,4 @@ package_list="software-properties-common python-software-properties wget \
 hdf5_libdir=/usr/lib/x86_64-linux-gnu/hdf5/serial
 
 
-source ubuntu_mint.sh
+source ubuntu_mint.sh $1

--- a/ubuntu_mint.sh
+++ b/ubuntu_mint.sh
@@ -117,10 +117,10 @@ build_moab
 
 build_pytaps
 
-install_pyne
+install_pyne $1
 
 nuc_data_make
 
-test_pyne
+test_pyne $1
 
 echo "PyNE build complete. PyNE can be rebuilt with the alias 'build_pyne' executed from $install_dir/pyne"

--- a/ubuntu_mint.sh
+++ b/ubuntu_mint.sh
@@ -74,10 +74,17 @@ function nuc_data_make {
 }
 
 function test_pyne {
+    
+    # check which python version to run correct tests
+    version=`python -c 'import sys; print(sys.version_info[:][0])'`
 
     # Run all the tests
     cd tests
-    source ./travis-run-tests.sh
+    if [ $version == '2' ] ; then
+        source ./travis-run-tests.sh python2
+    elif [ $version == '3' ] ; then
+        source ./travis-run-tests.sh python3
+    fi
 
 }
 

--- a/ubuntu_mint.sh
+++ b/ubuntu_mint.sh
@@ -79,6 +79,8 @@ function nuc_data_make {
 
 function test_pyne {
     
+    cd tests
+    
     # only test for python version if using the most recent dev branch
     if [ $1 == 'dev' ] ; then
     
@@ -86,7 +88,6 @@ function test_pyne {
         version=`python -c 'import sys; print(sys.version_info[:][0])'`
 
         # Run all the tests
-        cd tests
         if [ $version == '2' ] ; then
             source ./travis-run-tests.sh python2
         elif [ $version == '3' ] ; then

--- a/ubuntu_mint.sh
+++ b/ubuntu_mint.sh
@@ -58,6 +58,10 @@ function install_pyne {
     check_repo pyne
     git clone https://github.com/pyne/pyne.git
     cd pyne
+    if [ $1 == 'stable' ] ; then
+        TAG=$(git describe --abbrev=0 --tags)
+        git checkout tags/`echo $TAG` -b `echo $TAG`
+    fi
     python setup.py install --user -- -DMOAB_LIBRARY=$install_dir/moab/lib -DMOAB_INCLUDE_DIR=$install_dir/moab/include
     echo "export PATH=$HOME/.local/bin:\$PATH" >> ~/.bashrc
     echo "export LD_LIBRARY_PATH=$HOME/.local/lib:\$LD_LIBRARY_PATH" >> ~/.bashrc

--- a/ubuntu_mint.sh
+++ b/ubuntu_mint.sh
@@ -79,17 +79,23 @@ function nuc_data_make {
 
 function test_pyne {
     
-    # check which python version to run correct tests
-    version=`python -c 'import sys; print(sys.version_info[:][0])'`
+    # only test for python version if using the most recent dev branch
+    if [ $1 == 'dev' ] ; then
+    
+        # check which python version to run correct tests
+        version=`python -c 'import sys; print(sys.version_info[:][0])'`
 
-    # Run all the tests
-    cd tests
-    if [ $version == '2' ] ; then
-        source ./travis-run-tests.sh python2
-    elif [ $version == '3' ] ; then
-        source ./travis-run-tests.sh python3
+        # Run all the tests
+        cd tests
+        if [ $version == '2' ] ; then
+            source ./travis-run-tests.sh python2
+        elif [ $version == '3' ] ; then
+            source ./travis-run-tests.sh python3
+        fi
+
+    elif [ $1 == 'stable' ] ; then
+        source ./travis-run-tests.sh
     fi
-
 }
 
 


### PR DESCRIPTION
Adds in the required python2 or python3 argument for travis-run-tests.sh for any "dev" build branch.

Adds a requirement for the .sh scripts to choose "dev" or "stable" when building.