### PR TITLE
Dockerfile to build PyNE against pyMOAB/DAGMC (and any combinaison)

### DIFF
--- a/make_pyne_docker_image.sh
+++ b/make_pyne_docker_image.sh
@@ -1,0 +1,112 @@
+#! /bin/bash
+
+#_____________________________________________________________________________
+# usage
+# call if option -h, -help or --help, display usage and quit
+function usage ()
+{
+echo "---------------------------------------------------------------------------"
+echo "---------------------- make_pyne_docker_image usage: ----------------------"
+echo " "
+echo "  -h|-help|--help: print help/usage "
+echo " "
+echo "  --moab|-moab|moab : add MOAB to the build "
+echo " "
+echo "  --pymoab|-pymoab|pymoab : add pyMOAB to the build (also enable MOAB) "
+echo " "
+echo "  --dagmc|-dagmc|dagmc : add DAGMC to the build (also enable MOAB) "
+echo " "
+echo "  --deps-only|-deps-only|deps-only|--deps|-deps|deps : only build "\
+    "dependencies (PyNE will not be build/installed)"
+echo " "
+echo "  -tag=*|--tag=*|tag=*|-t=*|--t=*|t=*: set the tag name of the "\
+            "created docker image, if not provided tag name will be form from "\
+            "the install option : 
+            \"ubuntu_18.04(_pyne/_pyne-deps)(moab/pymoab/)(dagmc/) \""
+echo " "
+echo "---------------------------------------------------------------------------"
+exit 418 
+}
+
+
+# Parsing arguments
+MOAB=false
+DAGMC=false
+PYMOAB=false
+PYNE=true
+
+for arg in "$@"; do
+    case $arg in
+        -h|-help|--help )
+            usage 
+            ;;
+        --moab|-moab|moab )
+            MOAB=true
+            ;;
+        --dagmc|-dagmc|dagmc )
+            DAGMC=true 
+            MOAB=true 
+            ;;
+        --pymoab|-pymoab|pymoab )
+            PYMOAB=true 
+            MOAB=true 
+            ;;
+        --deps-only|-deps-only|deps-only )
+            PYNE=false 
+            ;;
+        --deps|-deps|deps )
+            PYNE=false 
+            ;;
+        -tag=*|--tag=*|tag=*|-t=*|--t=*|t=*)
+            img_tag="${arg#*=}"
+            shift # past argument=value
+            ;;
+    esac
+done
+
+# Parse option, form arguments
+pyne_option='_pyne'
+if  $MOAB; then
+    moab_arg='--build-arg build_moab=YES'
+    moab_option='_moab'
+fi
+if  $DAGMC; then
+    dagmc_arg='--build-arg build_dagmc=YES'
+    dagmc_option='_dagmc'
+    moab_option=''
+fi
+if  $PYMOAB; then
+    pymoab_arg='--build-arg enable_pymoab=YES'
+    pymoab_option='_pymoab'
+    moab_option-''
+fi
+if  ! $PYNE ; then
+    pyne_arg='--build-arg build_pyne=NO'
+    pyne_option='_pyne-deps'
+fi
+
+# if no image tag, create it
+if [ -z "$img_tag" ]; then
+    img_tag=ubuntu_18.04${pyne_option}${moab_option}${pymoab_option}${dagmc_option}
+fi
+
+docker build -t ${img_tag} -f ubuntu_18.04-dev.dockerfile ${moab_arg} ${dagmc_arg} ${pymoab_arg} ${pyne_arg} .
+
+
+
+exit 0
+
+EOF
+##############################################################################
+
+%DOC
+
+# Exit status
+In `bash`, a correct exectution of a script return an exit status equals to `0` (that why a *C*/*C++* program end by `return 0;`). There is NO standard for other exit status, so I (Josselin Massot) use the list of status code in HTTP for exit status.
+
+* `404` : *Not Found*, a test find a file which doesn't exist.
+* `418` : *I'm a teapot*, if only return help (I don't find a correct exit status for this).
+* `501` : *Not Implemented*, test a feature which doesn't implemented on OS.
+* `505` : *HTTP Version NOt supported*, the version of a library is NOt the one is expected.
+* `507` : *Insufficient storage*, an error on making a directory, maybe because of the insufficient storage.
+

--- a/ubuntu_18.04-dev.dockerfile
+++ b/ubuntu_18.04-dev.dockerfile
@@ -25,46 +25,48 @@ RUN apt-get update \
             cython
 
 # Script conditional setup: Default PyNE alone
-ARG build_moab=no
-ARG enable_pymoab=no
-ARG build_dagmc=no
+ARG build_moab=NO
+ARG enable_pymoab=NO
+ARG build_dagmc=NO
+ARG build_pyne=YES
 
 # make starting directory
 RUN mkdir -p $HOME/opt
 RUN echo "export PATH=$HOME/.local/bin:\$PATH" >> ~/.bashrc
 
 # build MOAB
-RUN if [ "$enable_pymoab" = "yes" ] || [ "$build_moab" = "yes" ] || [ "$build_dagmc" = "yes" ] ; then \
-        if [ "$enable_pymoab" = "yes" ] ; \
+RUN if [ "$build_moab" = "YES" ] || [ "$build_dagmc" = "YES" ] || [ "$enable_pymoab" = "YES" ] ; then \
+        if [ "$enable_pymoab" = "YES" ] ; \
         then \ 
             export PYMOAB_FLAG="-DENABLE_PYMOAB=ON"; \
         fi;\
-    echo $PYMOAB_FLAG \
-    && cd $HOME/opt \
-    && mkdir moab \
-    && cd moab \
-    && git clone https://bitbucket.org/fathomteam/moab \
-    && cd moab \
-    && git checkout -b Version5.1.0 origin/Version5.1.0 \
-    && cd .. \
-    && mkdir build \
-    && cd build \
-    && ls ../moab/ \
-    && cmake ../moab/ \
-          -DCMAKE_INSTALL_PREFIX=$HOME/opt/moab \
-          -DENABLE_HDF5=ON \
-    && make -j 3 \
-    && make install \
-  # build/install static lib
-    && cmake ../moab/ \
-          ${PYMOAB_FLAG} \
-          -DCMAKE_INSTALL_PREFIX=$HOME/opt/moab \
-          -DENABLE_HDF5=ON \
-          -DBUILD_SHARED_LIBS=OFF \
-    && make -j 3 \
-    && make install \
-    && cd .. \
-    && rm -rf build moab; \
+        echo $PYMOAB_FLAG \
+        && cd $HOME/opt \
+        && mkdir moab \
+        && cd moab \
+        && git clone https://bitbucket.org/fathomteam/moab \
+        && cd moab \
+        && git checkout -b Version5.1.0 origin/Version5.1.0 \
+        && cd .. \
+        && mkdir build \
+        && cd build \
+        && ls ../moab/ \
+        && cmake ../moab/ \
+              ${PYMOAB_FLAG} \
+              -DCMAKE_INSTALL_PREFIX=$HOME/opt/moab \
+              -DENABLE_HDF5=ON \
+        && make -j 3 \
+        && make install \
+      # build/install static lib
+        && cmake ../moab/ \
+              ${PYMOAB_FLAG} \
+              -DCMAKE_INSTALL_PREFIX=$HOME/opt/moab \
+              -DENABLE_HDF5=ON \
+              -DBUILD_SHARED_LIBS=OFF \
+        && make -j 3 \
+        && make install \
+        && cd .. \
+        && rm -rf build moab ; \
     fi
 
 # put MOAB on the path
@@ -74,28 +76,32 @@ ENV PYTHONPATH=$HOME/opt/moab/lib/python2.7/site-packages/
 
 # build/install DAGMC
 ENV INSTALL_PATH=$HOME/opt/dagmc
-RUN if [ "$DAGMC" = "TRUE" ]; then \
-      cd /root \
-      && git clone https://github.com/svalinn/DAGMC.git \
-      && cd DAGMC \
-      && git checkout develop \
-      && mkdir bld \
-      && cd bld \
-      && cmake .. -DMOAB_DIR=$HOME/opt/moab \
-               -DCMAKE_INSTALL_PREFIX=$INSTALL_PATH \
-      && make \
-      && make install; \
+RUN if [ "$build_dagmc" = "YES" ]; then \
+        cd /root \
+        && git clone https://github.com/svalinn/DAGMC.git \
+        && cd DAGMC \
+        && git checkout develop \
+        && mkdir bld \
+        && cd bld \
+        && cmake .. -DMOAB_DIR=$HOME/opt/moab \
+                 -DCMAKE_INSTALL_PREFIX=$INSTALL_PATH \
+        && make \
+        && make install ; \
     fi
 
 # Build/Install PyNE
-#RUN cd $HOME/opt \
-#    && git clone https://github.com/cnerg/pyne.git \
-#    && cd pyne \
-#    && git checkout pymoab_cleanup \
-#    && python setup.py install --user \
-#                                --moab $HOME/opt/moab --dagmc $HOME/opt/dagmc --clean
-#
-#ENV PATH $HOME/.local/bin:$PATH
-#RUN cd $HOME \
-#    && nuc_data_make
+RUN if [ "$build_pyne" = "YES" ]; then \
+        cd $HOME/opt \
+        && git clone https://github.com/cnerg/pyne.git \
+        && cd pyne \
+        && git checkout pymoab_cleanup \
+        && python setup.py install --user \
+                                    --moab $HOME/opt/moab --dagmc $HOME/opt/dagmc \
+                                    --clean ; \
+    fi
+ENV PATH $HOME/.local/bin:$PATH
+RUN if [ "$build_pyne" = "YES" ]; then \
+        cd $HOME \
+        && nuc_data_make ; \
+    fi
 

--- a/ubuntu_18.04-dev.dockerfile
+++ b/ubuntu_18.04-dev.dockerfile
@@ -1,0 +1,100 @@
+FROM ubuntu:18.04
+
+# Ubuntu Setup
+ENV TZ=America/Chicago
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+ENV HOME /root
+RUN apt-get update \
+    && apt-get install -y --fix-missing \
+            software-properties-common wget g++ \
+            build-essential python-numpy python-scipy cython python-setuptools \
+            python-nose git cmake vim emacs gfortran libblas-dev \
+            liblapack-dev libhdf5-dev libhdf5-serial-dev gfortran python-tables \
+            python-matplotlib python-jinja2 python-dev libpython-dev \
+            autoconf libtool python-setuptools python-pip doxygen \
+    && apt-get clean -y \
+    && pip install --force-reinstall \
+            sphinx \
+            cloud_sptheme \
+            prettytable \
+            sphinxcontrib_bibtex \
+            numpydoc \
+            nbconvert \
+            numpy \
+            cython
+
+# Script conditional setup: Default PyNE alone
+ARG build_moab=no
+ARG enable_pymoab=no
+ARG build_dagmc=no
+
+# make starting directory
+RUN mkdir -p $HOME/opt
+RUN echo "export PATH=$HOME/.local/bin:\$PATH" >> ~/.bashrc
+
+# build MOAB
+RUN if [ "$enable_pymoab" = "yes" ] || [ "$build_moab" = "yes" ] || [ "$build_dagmc" = "yes" ] ; then \
+        if [ "$enable_pymaob" = "yes" ] ; \
+        then \ 
+            PYMOAB_FLAG="-DENABLE_PYMOAB=ON"; \
+        fi;\
+    cd $HOME/opt \
+    && mkdir moab \
+    && cd moab \
+    && git clone https://bitbucket.org/fathomteam/moab \
+    && cd moab \
+    && git checkout -b Version5.1.0 origin/Version5.1.0 \
+    && cd .. \
+    && mkdir build \
+    && cd build \
+    && ls ../moab/ \
+    && cmake ../moab/ \
+          -DCMAKE_INSTALL_PREFIX=$HOME/opt/moab \
+          -DENABLE_HDF5=ON \
+    && make -j 3 \
+    && make install \
+  # build/install static lib
+    && cmake ../moab/ \
+          ${PYMOAB_FLAG} \
+          -DCMAKE_INSTALL_PREFIX=$HOME/opt/moab \
+          -DENABLE_HDF5=ON \
+          -DBUILD_SHARED_LIBS=OFF \
+    && make -j 3 \
+    && make install \
+    && cd .. \
+    && rm -rf build moab; \
+    fi
+
+# put MOAB on the path
+ENV LD_LIBRARY_PATH $HOME/opt/moab/lib:$LD_LIBRARY_PATH
+ENV LIBRARY_PATH $HOME/opt/moab/lib:$LIBRARY_PATH
+ENV PYTHONPATH=$HOME/opt/moab/lib/python2.7/site-packages/
+
+# build/install DAGMC
+ENV INSTALL_PATH=$HOME/opt/dagmc
+RUN if [ "$DAGMC" = "TRUE" ]; then \
+      cd /root \
+      && git clone https://github.com/svalinn/DAGMC.git \
+      && cd DAGMC \
+      && git checkout develop \
+      && mkdir bld \
+      && cd bld \
+      && cmake .. -DMOAB_DIR=$HOME/opt/moab \
+               -DCMAKE_INSTALL_PREFIX=$INSTALL_PATH \
+      && make \
+      && make install; \
+    fi
+
+# Build/Install PyNE
+#RUN cd $HOME/opt \
+#    && git clone https://github.com/cnerg/pyne.git \
+#    && cd pyne \
+#    && git checkout pymoab_cleanup \
+#    && python setup.py install --user \
+#                                --moab $HOME/opt/moab --dagmc $HOME/opt/dagmc --clean
+#
+#ENV PATH $HOME/.local/bin:$PATH
+#RUN cd $HOME \
+#    && nuc_data_make
+

--- a/ubuntu_18.04-dev.dockerfile
+++ b/ubuntu_18.04-dev.dockerfile
@@ -35,11 +35,12 @@ RUN echo "export PATH=$HOME/.local/bin:\$PATH" >> ~/.bashrc
 
 # build MOAB
 RUN if [ "$enable_pymoab" = "yes" ] || [ "$build_moab" = "yes" ] || [ "$build_dagmc" = "yes" ] ; then \
-        if [ "$enable_pymaob" = "yes" ] ; \
+        if [ "$enable_pymoab" = "yes" ] ; \
         then \ 
-            PYMOAB_FLAG="-DENABLE_PYMOAB=ON"; \
+            export PYMOAB_FLAG="-DENABLE_PYMOAB=ON"; \
         fi;\
-    cd $HOME/opt \
+    echo $PYMOAB_FLAG \
+    && cd $HOME/opt \
     && mkdir moab \
     && cd moab \
     && git clone https://bitbucket.org/fathomteam/moab \


### PR DESCRIPTION
this dockerfile should allow to build a PyNE container with any combinaison of:
- MOAB
- DAGMC
- PyMOAB

with the ubuntu version as an argument

Build command will look like:
`docker build -t tt -f ubuntu_18.04-dev.dockerfile --build-arg build_dagmc="yes"  .`
with possible --build-arg:
- build_dagmc
- build_moab
- enable_pymoab
- ubuntu

**EDIT:**

I added a script that allows to build the docker image you want (calling `docker build` with the right options)

the usage is:
` make_pyne_docker_image.sh moab pymoab dagmc -t=my_image_tag_name`
you can also specify `deps-only` or `deps` to avoid including PyNE in the image

if the tag name is not specified is it form from the option you have enabled:
`ubuntu_18.04` `_pyne/_pyne-deps` `moab/pymoab/` `dagmc/`