### PR TITLE
run nuc_data_make using installed command

### DIFF
--- a/ubuntu_16.04-dev.dockerfile
+++ b/ubuntu_16.04-dev.dockerfile
@@ -82,7 +82,7 @@ RUN echo "export PATH=$HOME/.local/bin:\$PATH" >> ~/.bashrc \
 
 ENV LD_LIBRARY_PATH $HOME/.local/lib:$LD_LIBRARY_PATH
 
-RUN cd $HOME/opt/pyne && ./scripts/nuc_data_make
+RUN cd $HOME && nuc_data_make
 
 RUN cd $HOME/opt/pyne/tests \
     && ./travis-run-tests.sh python2 \

--- a/ubuntu_16.04-stable.dockerfile
+++ b/ubuntu_16.04-stable.dockerfile
@@ -84,7 +84,7 @@ RUN echo "export PATH=$HOME/.local/bin:\$PATH" >> ~/.bashrc \
 
 ENV LD_LIBRARY_PATH $HOME/.local/lib:$LD_LIBRARY_PATH
 
-RUN cd $HOME/opt/pyne && ./scripts/nuc_data_make
+RUN cd $HOME && nuc_data_make
 
 RUN cd $HOME/opt/pyne/tests \
     && ./travis-run-tests.sh python2 \

--- a/ubuntu_18.04-dev.dockerfile
+++ b/ubuntu_18.04-dev.dockerfile
@@ -82,7 +82,7 @@ RUN echo "export PATH=$HOME/.local/bin:\$PATH" >> ~/.bashrc \
 
 ENV LD_LIBRARY_PATH $HOME/.local/lib:$LD_LIBRARY_PATH
 
-RUN cd $HOME/opt/pyne && ./scripts/nuc_data_make
+RUN cd $HOME && nuc_data_make
 
 RUN cd $HOME/opt/pyne/tests \
     && ./travis-run-tests.sh python2 \

--- a/ubuntu_18.04-stable.dockerfile
+++ b/ubuntu_18.04-stable.dockerfile
@@ -84,7 +84,7 @@ RUN echo "export PATH=$HOME/.local/bin:\$PATH" >> ~/.bashrc \
 
 ENV LD_LIBRARY_PATH $HOME/.local/lib:$LD_LIBRARY_PATH
 
-RUN cd $HOME/opt/pyne && ./scripts/nuc_data_make
+RUN cd $HOME && nuc_data_make
 
 RUN cd $HOME/opt/pyne/tests \
     && ./travis-run-tests.sh python2 \

--- a/ubuntu_mint.sh
+++ b/ubuntu_mint.sh
@@ -100,7 +100,8 @@ function nuc_data_make {
 
     # Generate nuclear data file
     export LD_LIBRARY_PATH=${HOME}/.local/lib:${LD_LIBRARY_PATH}
-    ./scripts/nuc_data_make
+    cd ${HOME}
+    nuc_data_make
 
 }
 


### PR DESCRIPTION
Fixes issue #58. This calls `nuc_data_make` using the installed version from the home directory rather than calling from inside the PyNE source which can cause unreliable import errors.