### PR TITLE
OpenMC install as an optional dependency

### DIFF
--- a/ubuntu.sh
+++ b/ubuntu.sh
@@ -156,11 +156,12 @@ export PATH="${HOME}/.local/bin:$PATH"
 cd  # cd without argument will take you back to your $HOME directory
 nuc_data_make
 
-cd ~/opt
+# OpenMC API
+cd ${install_dir}
 git clone https://github.com/openmc-dev/openmc.git
 cd openmc
 git checkout develop
-pip install .
+pip3 install .
 
 # Run tests
 cd ${install_dir}/pyne/tests

--- a/ubuntu.sh
+++ b/ubuntu.sh
@@ -124,6 +124,15 @@ export LD_LIBRARY_PATH="${install_dir}/dagmc/lib:$LD_LIBRARY_PATH"
 # Adding dagmc/bin to $PATH
 export PATH="${install_dir}/dagmc/bin:$PATH"
 
+####################
+### OpenMC API #####
+####################
+
+cd ${install_dir}
+git clone https://github.com/openmc-dev/openmc.git
+cd openmc
+git checkout develop
+pip3 install .
 
 ############
 ### PyNE ###
@@ -155,13 +164,6 @@ export PATH="${HOME}/.local/bin:$PATH"
 # Make Pyne Nuclear Data
 cd  # cd without argument will take you back to your $HOME directory
 nuc_data_make
-
-# OpenMC API
-cd ${install_dir}
-git clone https://github.com/openmc-dev/openmc.git
-cd openmc
-git checkout develop
-pip3 install .
 
 # Run tests
 cd ${install_dir}/pyne/tests

--- a/ubuntu.sh
+++ b/ubuntu.sh
@@ -132,6 +132,12 @@ cd ${install_dir}
 git clone https://github.com/openmc-dev/openmc.git
 cd openmc
 git checkout develop
+mkdir bld
+cd bld
+cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/.local
+make
+make install
+cd ..
 pip3 install .
 
 ############

--- a/ubuntu.sh
+++ b/ubuntu.sh
@@ -156,6 +156,12 @@ export PATH="${HOME}/.local/bin:$PATH"
 cd  # cd without argument will take you back to your $HOME directory
 nuc_data_make
 
+cd ~/opt
+git clone https://github.com/openmc-dev/openmc.git
+cd openmc
+git checkout develop
+pip install .
+
 # Run tests
 cd ${install_dir}/pyne/tests
 ./travis-run-tests.sh

--- a/ubuntu_18.04-dev.dockerfile
+++ b/ubuntu_18.04-dev.dockerfile
@@ -83,7 +83,10 @@ RUN mkdir dagmc \
 # Install OpenMC API
 RUN git clone https://github.com/openmc-dev/openmc.git \
     && cd openmc && git checkout develop \
-    && pip install .
+    && mkdir bld && cd bld \
+    && cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/.local \
+    && make && make install \
+    && cd .. && pip install .
 
 # Install PyNE
 RUN git clone https://github.com/pyne/pyne.git \

--- a/ubuntu_18.04-dev.dockerfile
+++ b/ubuntu_18.04-dev.dockerfile
@@ -98,9 +98,9 @@ ENV LD_LIBRARY_PATH $HOME/.local/lib:$LD_LIBRARY_PATH
 RUN cd $HOME && nuc_data_make
 
 # Install OpenMC API
-RUN cd $HOME/opt && git clone https://github.com/openmc-dev/openmc.git
-RUN cd $HOME/opt/openmc && git checkout develop
-RUN pip install .
+RUN cd $HOME/opt && git clone https://github.com/openmc-dev/openmc.git \
+    && cd $HOME/opt/openmc && git checkout develop \
+    && pip install .
 
 RUN cd $HOME/opt/pyne/tests \
     && ./travis-run-tests.sh \

--- a/ubuntu_18.04-dev.dockerfile
+++ b/ubuntu_18.04-dev.dockerfile
@@ -81,7 +81,7 @@ RUN mkdir dagmc \
     && rm -rf build DAGMC
 
 # Install OpenMC API
-RUN cd git clone https://github.com/openmc-dev/openmc.git \
+RUN git clone https://github.com/openmc-dev/openmc.git \
     && cd openmc && git checkout develop \
     && pip install . \
     && cd ..

--- a/ubuntu_18.04-dev.dockerfile
+++ b/ubuntu_18.04-dev.dockerfile
@@ -80,6 +80,11 @@ RUN mkdir dagmc \
     && cd .. \
     && rm -rf build DAGMC
 
+# Install OpenMC API
+RUN cd git clone https://github.com/openmc-dev/openmc.git \
+    && cd openmc && git checkout develop \
+    && pip install . \
+    && cd ..
 
 # Install PyNE
 RUN git clone https://github.com/pyne/pyne.git \
@@ -96,11 +101,6 @@ RUN echo "export PATH=$HOME/.local/bin:\$PATH" >> ~/.bashrc \
 ENV LD_LIBRARY_PATH $HOME/.local/lib:$LD_LIBRARY_PATH
 
 RUN cd $HOME && nuc_data_make
-
-# Install OpenMC API
-RUN cd $HOME/opt && git clone https://github.com/openmc-dev/openmc.git \
-    && cd $HOME/opt/openmc && git checkout develop \
-    && pip install .
 
 RUN cd $HOME/opt/pyne/tests \
     && ./travis-run-tests.sh \

--- a/ubuntu_18.04-dev.dockerfile
+++ b/ubuntu_18.04-dev.dockerfile
@@ -102,6 +102,6 @@ ENV LD_LIBRARY_PATH $HOME/.local/lib:$LD_LIBRARY_PATH
 
 RUN cd $HOME && nuc_data_make
 
-RUN cd $HOME/opt/pyne/tests \
+RUN cd pyne/tests \
     && ./travis-run-tests.sh \
     && echo "PyNE build complete. PyNE can be rebuilt with the alias 'build_pyne' executed from $HOME/opt/pyne"

--- a/ubuntu_18.04-dev.dockerfile
+++ b/ubuntu_18.04-dev.dockerfile
@@ -83,8 +83,7 @@ RUN mkdir dagmc \
 # Install OpenMC API
 RUN git clone https://github.com/openmc-dev/openmc.git \
     && cd openmc && git checkout develop \
-    && pip install . \
-    && cd ..
+    && pip install .
 
 # Install PyNE
 RUN git clone https://github.com/pyne/pyne.git \

--- a/ubuntu_18.04-dev.dockerfile
+++ b/ubuntu_18.04-dev.dockerfile
@@ -97,6 +97,11 @@ ENV LD_LIBRARY_PATH $HOME/.local/lib:$LD_LIBRARY_PATH
 
 RUN cd $HOME && nuc_data_make
 
-RUN cd pyne/tests \
+# Install OpenMC API
+RUN cd $HOME/opt && git clone https://github.com/openmc-dev/openmc.git
+RUN cd $HOME/opt/openmc && git checkout develop
+RUN pip install .
+
+RUN cd $HOME/opt/pyne/tests \
     && ./travis-run-tests.sh \
     && echo "PyNE build complete. PyNE can be rebuilt with the alias 'build_pyne' executed from $HOME/opt/pyne"

--- a/ubuntu_18.04-stable.dockerfile
+++ b/ubuntu_18.04-stable.dockerfile
@@ -83,7 +83,10 @@ RUN mkdir dagmc \
 # Install OpenMC API
 RUN git clone https://github.com/openmc-dev/openmc.git \
     && cd openmc && git checkout develop \
-    && pip install .
+    && mkdir bld && cd bld \
+    && cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/.local \
+    && make && make install \
+    && cd .. && pip install .
 
 # Install PyNE
 RUN git clone https://github.com/pyne/pyne.git \

--- a/ubuntu_18.04-stable.dockerfile
+++ b/ubuntu_18.04-stable.dockerfile
@@ -104,6 +104,6 @@ ENV LD_LIBRARY_PATH $HOME/.local/lib:$LD_LIBRARY_PATH
 
 RUN cd $HOME && nuc_data_make
 
-RUN cd $HOME/opt/pyne/tests \
+RUN cd pyne/tests \
     && ./travis-run-tests.sh \
     && echo "PyNE build complete. PyNE can be rebuilt with the alias 'build_pyne' executed from $HOME/opt/pyne"

--- a/ubuntu_18.04-stable.dockerfile
+++ b/ubuntu_18.04-stable.dockerfile
@@ -81,7 +81,7 @@ RUN mkdir dagmc \
     && rm -rf build DAGMC
 
 # Install OpenMC API
-RUN cd git clone https://github.com/openmc-dev/openmc.git \
+RUN git clone https://github.com/openmc-dev/openmc.git \
     && cd openmc && git checkout develop \
     && pip install . \
     && cd ..

--- a/ubuntu_18.04-stable.dockerfile
+++ b/ubuntu_18.04-stable.dockerfile
@@ -99,6 +99,11 @@ ENV LD_LIBRARY_PATH $HOME/.local/lib:$LD_LIBRARY_PATH
 
 RUN cd $HOME && nuc_data_make
 
-RUN cd pyne/tests \
+# Install OpenMC API
+RUN cd $HOME/opt && git clone https://github.com/openmc-dev/openmc.git
+RUN cd $HOME/opt/openmc && git checkout develop
+RUN pip install .
+
+RUN cd $HOME/opt/pyne/tests \
     && ./travis-run-tests.sh \
     && echo "PyNE build complete. PyNE can be rebuilt with the alias 'build_pyne' executed from $HOME/opt/pyne"

--- a/ubuntu_18.04-stable.dockerfile
+++ b/ubuntu_18.04-stable.dockerfile
@@ -100,9 +100,9 @@ ENV LD_LIBRARY_PATH $HOME/.local/lib:$LD_LIBRARY_PATH
 RUN cd $HOME && nuc_data_make
 
 # Install OpenMC API
-RUN cd $HOME/opt && git clone https://github.com/openmc-dev/openmc.git
-RUN cd $HOME/opt/openmc && git checkout develop
-RUN pip install .
+RUN cd $HOME/opt && git clone https://github.com/openmc-dev/openmc.git \
+    && cd $HOME/opt/openmc && git checkout develop \
+    && pip install .
 
 RUN cd $HOME/opt/pyne/tests \
     && ./travis-run-tests.sh \

--- a/ubuntu_18.04-stable.dockerfile
+++ b/ubuntu_18.04-stable.dockerfile
@@ -83,8 +83,7 @@ RUN mkdir dagmc \
 # Install OpenMC API
 RUN git clone https://github.com/openmc-dev/openmc.git \
     && cd openmc && git checkout develop \
-    && pip install . \
-    && cd ..
+    && pip install .
 
 # Install PyNE
 RUN git clone https://github.com/pyne/pyne.git \

--- a/ubuntu_18.04-stable.dockerfile
+++ b/ubuntu_18.04-stable.dockerfile
@@ -80,6 +80,11 @@ RUN mkdir dagmc \
     && cd .. \
     && rm -rf build DAGMC
 
+# Install OpenMC API
+RUN cd git clone https://github.com/openmc-dev/openmc.git \
+    && cd openmc && git checkout develop \
+    && pip install . \
+    && cd ..
 
 # Install PyNE
 RUN git clone https://github.com/pyne/pyne.git \
@@ -98,11 +103,6 @@ RUN echo "export PATH=$HOME/.local/bin:\$PATH" >> ~/.bashrc \
 ENV LD_LIBRARY_PATH $HOME/.local/lib:$LD_LIBRARY_PATH
 
 RUN cd $HOME && nuc_data_make
-
-# Install OpenMC API
-RUN cd $HOME/opt && git clone https://github.com/openmc-dev/openmc.git \
-    && cd $HOME/opt/openmc && git checkout develop \
-    && pip install .
 
 RUN cd $HOME/opt/pyne/tests \
     && ./travis-run-tests.sh \

--- a/ubuntu_20.04-dev.dockerfile
+++ b/ubuntu_20.04-dev.dockerfile
@@ -9,7 +9,7 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 # install apt dependencies
 RUN apt-get -y  update
 RUN apt-get install -y software-properties-common \
-                       python-is-python3 \
+                       python3-pip \
                        wget \
                        build-essential \
                        git \
@@ -24,8 +24,9 @@ RUN apt-get install -y software-properties-common \
 # need to put libhdf5.so on LD_LIBRARY_PATH
 ENV LD_LIBRARY_PATH /usr/lib/x86_64-linux-gnu
 
-# pip3 as pip sym link
-RUN ln -s /usr/bin/pip3 /usr/bin/pip
+# switch to python 3
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 10; \
+    update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 10;
 
 # upgrade pip and install python dependencies
 ENV PATH $HOME/.local/bin:$PATH
@@ -97,9 +98,9 @@ ENV LD_LIBRARY_PATH $HOME/.local/lib:$LD_LIBRARY_PATH
 RUN cd $HOME && nuc_data_make
 
 # Install OpenMC API
-RUN cd $HOME/opt && git clone https://github.com/openmc-dev/openmc.git
-RUN cd $HOME/opt/openmc && git checkout develop
-RUN pip install .
+RUN cd $HOME/opt && git clone https://github.com/openmc-dev/openmc.git \
+    && cd $HOME/opt/openmc && git checkout develop \
+    && pip install .
 
 RUN cd $HOME/opt/pyne/tests \
     && ./travis-run-tests.sh \

--- a/ubuntu_20.04-dev.dockerfile
+++ b/ubuntu_20.04-dev.dockerfile
@@ -83,7 +83,10 @@ RUN mkdir dagmc \
 # Install OpenMC API
 RUN git clone https://github.com/openmc-dev/openmc.git \
     && cd openmc && git checkout develop \
-    && pip install .
+    && mkdir bld && cd bld \
+    && cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/.local \
+    && make && make install \
+    && cd .. && pip install .
 
 # Install PyNE
 RUN git clone https://github.com/pyne/pyne.git \

--- a/ubuntu_20.04-dev.dockerfile
+++ b/ubuntu_20.04-dev.dockerfile
@@ -81,7 +81,7 @@ RUN mkdir dagmc \
     && rm -rf build DAGMC
 
 # Install OpenMC API
-RUN cd git clone https://github.com/openmc-dev/openmc.git \
+RUN git clone https://github.com/openmc-dev/openmc.git \
     && cd openmc && git checkout develop \
     && pip install . \
     && cd ..

--- a/ubuntu_20.04-dev.dockerfile
+++ b/ubuntu_20.04-dev.dockerfile
@@ -80,6 +80,11 @@ RUN mkdir dagmc \
     && cd .. \
     && rm -rf build DAGMC
 
+# Install OpenMC API
+RUN cd git clone https://github.com/openmc-dev/openmc.git \
+    && cd openmc && git checkout develop \
+    && pip install . \
+    && cd ..
 
 # Install PyNE
 RUN git clone https://github.com/pyne/pyne.git \
@@ -96,11 +101,6 @@ RUN echo "export PATH=$HOME/.local/bin:\$PATH" >> ~/.bashrc \
 ENV LD_LIBRARY_PATH $HOME/.local/lib:$LD_LIBRARY_PATH
 
 RUN cd $HOME && nuc_data_make
-
-# Install OpenMC API
-RUN cd $HOME/opt && git clone https://github.com/openmc-dev/openmc.git \
-    && cd $HOME/opt/openmc && git checkout develop \
-    && pip install .
 
 RUN cd $HOME/opt/pyne/tests \
     && ./travis-run-tests.sh \

--- a/ubuntu_20.04-dev.dockerfile
+++ b/ubuntu_20.04-dev.dockerfile
@@ -102,6 +102,6 @@ ENV LD_LIBRARY_PATH $HOME/.local/lib:$LD_LIBRARY_PATH
 
 RUN cd $HOME && nuc_data_make
 
-RUN cd $HOME/opt/pyne/tests \
+RUN cd pyne/tests \
     && ./travis-run-tests.sh \
     && echo "PyNE build complete. PyNE can be rebuilt with the alias 'build_pyne' executed from $HOME/opt/pyne"

--- a/ubuntu_20.04-dev.dockerfile
+++ b/ubuntu_20.04-dev.dockerfile
@@ -83,8 +83,7 @@ RUN mkdir dagmc \
 # Install OpenMC API
 RUN git clone https://github.com/openmc-dev/openmc.git \
     && cd openmc && git checkout develop \
-    && pip install . \
-    && cd ..
+    && pip install .
 
 # Install PyNE
 RUN git clone https://github.com/pyne/pyne.git \

--- a/ubuntu_20.04-dev.dockerfile
+++ b/ubuntu_20.04-dev.dockerfile
@@ -9,7 +9,7 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 # install apt dependencies
 RUN apt-get -y  update
 RUN apt-get install -y software-properties-common \
-                       python3-pip \
+                       python-is-python3 \
                        wget \
                        build-essential \
                        git \
@@ -24,9 +24,8 @@ RUN apt-get install -y software-properties-common \
 # need to put libhdf5.so on LD_LIBRARY_PATH
 ENV LD_LIBRARY_PATH /usr/lib/x86_64-linux-gnu
 
-# switch to python 3
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 10; \
-    update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 10;
+# pip3 as pip sym link
+RUN ln -s /usr/bin/pip3 /usr/bin/pip
 
 # upgrade pip and install python dependencies
 ENV PATH $HOME/.local/bin:$PATH
@@ -97,6 +96,11 @@ ENV LD_LIBRARY_PATH $HOME/.local/lib:$LD_LIBRARY_PATH
 
 RUN cd $HOME && nuc_data_make
 
-RUN cd pyne/tests \
+# Install OpenMC API
+RUN cd $HOME/opt && git clone https://github.com/openmc-dev/openmc.git
+RUN cd $HOME/opt/openmc && git checkout develop
+RUN pip install .
+
+RUN cd $HOME/opt/pyne/tests \
     && ./travis-run-tests.sh \
     && echo "PyNE build complete. PyNE can be rebuilt with the alias 'build_pyne' executed from $HOME/opt/pyne"

--- a/ubuntu_20.04-stable.dockerfile
+++ b/ubuntu_20.04-stable.dockerfile
@@ -83,7 +83,10 @@ RUN mkdir dagmc \
 # Install OpenMC API
 RUN git clone https://github.com/openmc-dev/openmc.git \
     && cd openmc && git checkout develop \
-    && pip install .
+    && mkdir bld && cd bld \
+    && cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/.local \
+    && make && make install \
+    && cd .. && pip install .
 
 # Install PyNE
 RUN git clone https://github.com/pyne/pyne.git \

--- a/ubuntu_20.04-stable.dockerfile
+++ b/ubuntu_20.04-stable.dockerfile
@@ -104,6 +104,6 @@ ENV LD_LIBRARY_PATH $HOME/.local/lib:$LD_LIBRARY_PATH
 
 RUN cd $HOME && nuc_data_make
 
-RUN cd $HOME/opt/pyne/tests \
+RUN cd pyne/tests \
     && ./travis-run-tests.sh \
     && echo "PyNE build complete. PyNE can be rebuilt with the alias 'build_pyne' executed from $HOME/opt/pyne"

--- a/ubuntu_20.04-stable.dockerfile
+++ b/ubuntu_20.04-stable.dockerfile
@@ -81,7 +81,7 @@ RUN mkdir dagmc \
     && rm -rf build DAGMC
 
 # Install OpenMC API
-RUN cd git clone https://github.com/openmc-dev/openmc.git \
+RUN git clone https://github.com/openmc-dev/openmc.git \
     && cd openmc && git checkout develop \
     && pip install . \
     && cd ..

--- a/ubuntu_20.04-stable.dockerfile
+++ b/ubuntu_20.04-stable.dockerfile
@@ -9,7 +9,7 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 # install apt dependencies
 RUN apt-get -y  update
 RUN apt-get install -y software-properties-common \
-                       python-is-python3 \
+                       python3-pip \
                        wget \
                        build-essential \
                        git \
@@ -24,8 +24,9 @@ RUN apt-get install -y software-properties-common \
 # need to put libhdf5.so on LD_LIBRARY_PATH
 ENV LD_LIBRARY_PATH /usr/lib/x86_64-linux-gnu
 
-# pip3 as pip sym link
-RUN ln -s /usr/bin/pip3 /usr/bin/pip
+# switch to python 3
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 10; \
+    update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 10;
 
 # upgrade pip and install python dependencies
 ENV PATH $HOME/.local/bin:$PATH
@@ -99,9 +100,9 @@ ENV LD_LIBRARY_PATH $HOME/.local/lib:$LD_LIBRARY_PATH
 RUN cd $HOME && nuc_data_make
 
 # Install OpenMC API
-RUN cd $HOME/opt && git clone https://github.com/openmc-dev/openmc.git
-RUN cd $HOME/opt/openmc && git checkout develop
-RUN pip install .
+RUN cd $HOME/opt && git clone https://github.com/openmc-dev/openmc.git \
+    && cd $HOME/opt/openmc && git checkout develop \
+    && pip install .
 
 RUN cd $HOME/opt/pyne/tests \
     && ./travis-run-tests.sh \

--- a/ubuntu_20.04-stable.dockerfile
+++ b/ubuntu_20.04-stable.dockerfile
@@ -9,7 +9,7 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 # install apt dependencies
 RUN apt-get -y  update
 RUN apt-get install -y software-properties-common \
-                       python3-pip \
+                       python-is-python3 \
                        wget \
                        build-essential \
                        git \
@@ -24,9 +24,8 @@ RUN apt-get install -y software-properties-common \
 # need to put libhdf5.so on LD_LIBRARY_PATH
 ENV LD_LIBRARY_PATH /usr/lib/x86_64-linux-gnu
 
-# switch to python 3
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 10; \
-    update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 10;
+# pip3 as pip sym link
+RUN ln -s /usr/bin/pip3 /usr/bin/pip
 
 # upgrade pip and install python dependencies
 ENV PATH $HOME/.local/bin:$PATH
@@ -99,6 +98,11 @@ ENV LD_LIBRARY_PATH $HOME/.local/lib:$LD_LIBRARY_PATH
 
 RUN cd $HOME && nuc_data_make
 
-RUN cd pyne/tests \
+# Install OpenMC API
+RUN cd $HOME/opt && git clone https://github.com/openmc-dev/openmc.git
+RUN cd $HOME/opt/openmc && git checkout develop
+RUN pip install .
+
+RUN cd $HOME/opt/pyne/tests \
     && ./travis-run-tests.sh \
     && echo "PyNE build complete. PyNE can be rebuilt with the alias 'build_pyne' executed from $HOME/opt/pyne"

--- a/ubuntu_20.04-stable.dockerfile
+++ b/ubuntu_20.04-stable.dockerfile
@@ -83,8 +83,7 @@ RUN mkdir dagmc \
 # Install OpenMC API
 RUN git clone https://github.com/openmc-dev/openmc.git \
     && cd openmc && git checkout develop \
-    && pip install . \
-    && cd ..
+    && pip install .
 
 # Install PyNE
 RUN git clone https://github.com/pyne/pyne.git \

--- a/ubuntu_20.04-stable.dockerfile
+++ b/ubuntu_20.04-stable.dockerfile
@@ -80,6 +80,11 @@ RUN mkdir dagmc \
     && cd .. \
     && rm -rf build DAGMC
 
+# Install OpenMC API
+RUN cd git clone https://github.com/openmc-dev/openmc.git \
+    && cd openmc && git checkout develop \
+    && pip install . \
+    && cd ..
 
 # Install PyNE
 RUN git clone https://github.com/pyne/pyne.git \
@@ -98,11 +103,6 @@ RUN echo "export PATH=$HOME/.local/bin:\$PATH" >> ~/.bashrc \
 ENV LD_LIBRARY_PATH $HOME/.local/lib:$LD_LIBRARY_PATH
 
 RUN cd $HOME && nuc_data_make
-
-# Install OpenMC API
-RUN cd $HOME/opt && git clone https://github.com/openmc-dev/openmc.git \
-    && cd $HOME/opt/openmc && git checkout develop \
-    && pip install .
 
 RUN cd $HOME/opt/pyne/tests \
     && ./travis-run-tests.sh \


### PR DESCRIPTION
Fixes #48 
@kkiesling already mentioned default python on 20.04 is **python 3**, so we need to create a symlink for  `pip3` as `pip`.
As far I know, For `Ubuntu 18.04`, the default python is  `python 3.6`. They recently removed `python2` with `python 3.6`.
Can we remove 
```
update-alternatives --install /usr/bin/python python /usr/bin/python3 10; \
update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 10
```
with
```
apt-get install python-is-python3
ln -s /usr/bin/pip3 /usr/bin/pip
```
for `ubuntu 18.04`?